### PR TITLE
lobsterparser: fix incorrect warning logic

### DIFF
--- a/tests/test_lobsterparser.py
+++ b/tests/test_lobsterparser.py
@@ -48,13 +48,15 @@ def approx(value):
     return pytest.approx(value, abs=0, rel=1e-6)
 
 
-def test_Fe(parser):
+def test_Fe(parser, caplog):
     """
     Tests spin-polarized Fe calculation with LOBSTER 4.0.0
     """
 
     archive = EntryArchive()
     parser.parse('tests/data/lobster/Fe/lobsterout', archive, logging)
+
+    assert len(caplog.records) == 0
 
     run = archive.run[0]
     assert run.program.name == "LOBSTER"
@@ -225,7 +227,7 @@ def test_Fe(parser):
     assert dos.atom_projected[13].value[35].magnitude == approx(0.01522 / eV)
 
 
-def test_NaCl(parser):
+def test_NaCl(parser, caplog):
     """
     Test non-spin-polarized NaCl calculation with LOBSTER 3.2.0
     """
@@ -386,7 +388,7 @@ def test_NaCl(parser):
     assert dos.atom_projected[16].value[152].magnitude == approx(0.00337 / eV)
 
 
-def test_HfV(parser):
+def test_HfV(parser, caplog):
     """
     Test non-spin-polarized HfV2 calculation with LOBSTER 2.0.0,
     it has different ICOHPLIST.lobster and ICOOPLIST.lobster scheme.
@@ -395,6 +397,8 @@ def test_HfV(parser):
 
     archive = EntryArchive()
     parser.parse('tests/data/lobster/HfV2/lobsterout', archive, logging)
+
+    assert len(caplog.records) == 1
 
     run = archive.run[0]
     assert run.program.name == "LOBSTER"
@@ -464,7 +468,7 @@ def test_HfV(parser):
         eV_to_J(-0.50035))
 
 
-def test_QE_Ni(parser):
+def test_QE_Ni(parser, caplog):
     """
     Check that basic info is parsed properly when LOBSTER is run on top
     of Quantum Espresso calculations.
@@ -472,6 +476,8 @@ def test_QE_Ni(parser):
 
     archive = EntryArchive()
     parser.parse('tests/data/lobster/Ni/lobsterout', archive, logging)
+
+    assert len(caplog.records) == 0
 
     run = archive.run[0]
 
@@ -502,7 +508,7 @@ def test_QE_Ni(parser):
     assert run.clean_end is True
 
 
-def test_failed_case(parser):
+def test_failed_case(parser, caplog):
     """
     Check that we also handle gracefully a case where the lobster ends very early.
     Here it is because of a wrong CONTCAR.
@@ -510,6 +516,8 @@ def test_failed_case(parser):
 
     archive = EntryArchive()
     parser.parse('tests/data/lobster/failed_case/lobsterout', archive, logging)
+
+    assert len(caplog.records) == 0
 
     run = archive.run[0]
     assert run.clean_end is False

--- a/workflowparsers/lobster/parser.py
+++ b/workflowparsers/lobster/parser.py
@@ -402,7 +402,7 @@ class LobsterParser:
                     structure = ase.io.read(contcar_path, format="vasp")
                 except FileNotFoundError:
                     logger.warning('Unable to parse structure info, no CONTCAR detected')
-            if code == 'Quantum Espresso':
+            elif code == 'Quantum Espresso':
                 for file in os.listdir(mainfile_path):
                     # lobster requires the QE input to have *.scf.in suffix
                     if file.endswith(".scf.in"):


### PR DESCRIPTION
Just something I messed up in the last patch, the parsed results were OK, just a warning was printed when it shouldn't be so add also few simple tests to catch this in future.