### PR TITLE
Fix spectra in XSPECTRA

### DIFF
--- a/tests/test_quantum_espresso_xspectra.py
+++ b/tests/test_quantum_espresso_xspectra.py
@@ -72,4 +72,4 @@ def test_1(parser):
     assert sec_spectra.type == 'XANES'
     assert sec_spectra.n_energies == 400
     assert sec_spectra.excitation_energies[22].magnitude == approx(-1.6523701378886513e-18)
-    assert sec_spectra.intensities[22] == approx(5.8321411406262735e-09)
+    assert sec_spectra.intensities[22] == approx(2.905e-5)

--- a/tests/test_quantum_espresso_xspectra.py
+++ b/tests/test_quantum_espresso_xspectra.py
@@ -72,4 +72,5 @@ def test_1(parser):
     assert sec_spectra.type == 'XANES'
     assert sec_spectra.n_energies == 400
     assert sec_spectra.excitation_energies[22].magnitude == approx(-1.6523701378886513e-18)
-    assert sec_spectra.intensities[22] == approx(-4.126638362437578e-12)
+    assert sec_spectra.energy_zero_ref.to('eV').magnitude == approx(-15.157)
+    assert sec_spectra.intensities[22] == approx(5.8321411406262735e-09)

--- a/tests/test_quantum_espresso_xspectra.py
+++ b/tests/test_quantum_espresso_xspectra.py
@@ -72,5 +72,4 @@ def test_1(parser):
     assert sec_spectra.type == 'XANES'
     assert sec_spectra.n_energies == 400
     assert sec_spectra.excitation_energies[22].magnitude == approx(-1.6523701378886513e-18)
-    assert sec_spectra.energy_zero_ref.to('eV').magnitude == approx(-15.157)
     assert sec_spectra.intensities[22] == approx(5.8321411406262735e-09)

--- a/workflowparsers/quantum_espresso_xspectra/parser.py
+++ b/workflowparsers/quantum_espresso_xspectra/parser.py
@@ -402,10 +402,6 @@ class QuantumEspressoXSpectraParser:
                     setattr(sec_spectra, f'x_qe_xspectra_{key}', val)
             sec_spectra.type = self.mainfile_parser.input.get('x_qe_xspectra_calculation', '').split('_')[0].upper()
             sec_spectra.n_energies = data.shape[0]
-            energy_ref = 0.0 * ureg.eV
-            if self.mainfile_parser.xanes.get('step_2', {}) .get('energy_zero'):
-                energy_ref = self.mainfile_parser.xanes.get('step_2', {}).get('energy_zero')
-                sec_spectra.energy_zero_ref = - energy_ref  # TODO check this sign with devs
             sec_spectra.excitation_energies = data[:, 0] * ureg.eV
             unit_cell_volume = self.mainfile_parser.get('unit_cell_volume').magnitude  # in bohr^3
             # TODO check with devs, not sure if this expression is correct or whether it is simply about renormalizing by the unit_cell_volume

--- a/workflowparsers/quantum_espresso_xspectra/parser.py
+++ b/workflowparsers/quantum_espresso_xspectra/parser.py
@@ -19,7 +19,6 @@
 import logging
 import os
 import numpy as np
-import scipy.constants
 from datetime import datetime
 
 from nomad.units import ureg
@@ -404,8 +403,8 @@ class QuantumEspressoXSpectraParser:
             sec_spectra.n_energies = data.shape[0]
             sec_spectra.excitation_energies = data[:, 0] * ureg.eV
             # TODO check with devs, not sure if this expression is correct or whether it is simply about renormalizing by the unit_cell_volume
-            unit_cell_volume = self.mainfile_parser.get('unit_cell_volume').magnitude  # in bohr^3
-            sec_spectra.intensities = data[:, 1] / unit_cell_volume
+            sec_spectra.intensities = data[:, 1]
+            # unit_cell_volume = self.mainfile_parser.get('unit_cell_volume').magnitude  # in bohr^3
             # sec_spectra.intensities = scipy.constants.fine_structure * data[:, 1] / (energies * unit_cell_volume)
 
     def parse(self, filepath, archive, logger):

--- a/workflowparsers/quantum_espresso_xspectra/parser.py
+++ b/workflowparsers/quantum_espresso_xspectra/parser.py
@@ -403,10 +403,10 @@ class QuantumEspressoXSpectraParser:
             sec_spectra.type = self.mainfile_parser.input.get('x_qe_xspectra_calculation', '').split('_')[0].upper()
             sec_spectra.n_energies = data.shape[0]
             sec_spectra.excitation_energies = data[:, 0] * ureg.eV
-            unit_cell_volume = self.mainfile_parser.get('unit_cell_volume').magnitude  # in bohr^3
             # TODO check with devs, not sure if this expression is correct or whether it is simply about renormalizing by the unit_cell_volume
-            # sec_spectra.intensities = scipy.constants.fine_structure * data[:, 1] / (energies * unit_cell_volume)
+            unit_cell_volume = self.mainfile_parser.get('unit_cell_volume').magnitude  # in bohr^3
             sec_spectra.intensities = data[:, 1] / unit_cell_volume
+            # sec_spectra.intensities = scipy.constants.fine_structure * data[:, 1] / (energies * unit_cell_volume)
 
     def parse(self, filepath, archive, logger):
         self.logger = logging.getLogger(__name__) if logger is None else logger


### PR DESCRIPTION
I have changed the way of storing `Spectra.intensities` in XSPECTRA because the previous formula was giving errors. I will clarify the situation with the developers before making a decision, but the current formula makes more "physical sense", thought it might be missing some factors.

@ladinesa what do you think is better? Defining `sec_spectra.intensities = data[:, 1]` or normalize by the `unit_cell_volume`. It does not matter to much at the end of the day, as our own Spectra normalization will renormalize these intensities to their maximum value.