### PR TITLE
Remove references to workflow schema in nomad

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ authors = [{ name = "The NOMAD Authors" }]
 license = { file = "LICENSE" }
 dependencies = [
     'nomad-lab[infrastructure]@git+https://github.com/nomad-coe/nomad.git@develop',
+    "nomad-schema-plugin-simulation-workflow@git+https://github.com/nomad-coe/nomad-schema-plugin-simulation-workflow.git@develop",
     'lxml',
     'asr',
     'xarray>=0.19.0',

--- a/workflowparsers/aflow/parser.py
+++ b/workflowparsers/aflow/parser.py
@@ -32,7 +32,7 @@ from nomad.datamodel.metainfo.simulation.calculation import (
     Thermodynamics, Dos, DosValues, BandStructure, BandEnergies)
 from nomad.datamodel.metainfo.simulation.method import Method
 from nomad.datamodel.metainfo.simulation.system import System, Atoms
-from nomad.datamodel.metainfo.simulation.workflow import (
+from simulationworkflowschema import (
     Elastic, ElasticMethod, ElasticResults, Phonon, PhononMethod, PhononResults,
     Thermodynamics as WorkflowThermodynamics, ThermodynamicsResults
 )

--- a/workflowparsers/asr/parser.py
+++ b/workflowparsers/asr/parser.py
@@ -36,7 +36,7 @@ from nomad.datamodel.metainfo.simulation.system import System, Atoms
 from nomad.datamodel.metainfo.simulation.calculation import (
     Calculation, BandStructure, BandEnergies, Energy, EnergyEntry, Forces, ForcesEntry,
     Stress, StressEntry)
-from nomad.datamodel.metainfo.simulation.workflow import (
+from simulationworkflowschema import (
     GeometryOptimization, Phonon
 )
 from .metainfo.asr import (

--- a/workflowparsers/atomate/parser.py
+++ b/workflowparsers/atomate/parser.py
@@ -23,11 +23,13 @@ import numpy as np
 
 from nomad.units import ureg
 from nomad.datamodel.metainfo.simulation.run import Run, Program
-from nomad.datamodel.metainfo.simulation.workflow import (
+from simulationworkflowschema import (
     Elastic, ElasticMethod, ElasticResults, EquationOfState, EquationOfStateMethod,
-    EquationOfStateResults, EOSFit, Thermodynamics, ThermodynamicsResults,
-    Stability, Decomposition, Phonon, PhononMethod, PhononResults
+    EquationOfStateResults, Thermodynamics, ThermodynamicsResults,
+    Phonon, PhononMethod, PhononResults
 )
+from simulationworkflowschema.equation_of_state import EOSFit
+from simulationworkflowschema.thermodynamics import Stability, Decomposition
 from nomad.datamodel.metainfo.simulation.system import System, Atoms
 from nomad.datamodel.metainfo.simulation.method import (
     Method, DFT, Electronic, XCFunctional, Functional, BasisSet, BasisSetContainer,)

--- a/workflowparsers/elastic/parser.py
+++ b/workflowparsers/elastic/parser.py
@@ -28,9 +28,9 @@ from nomad.datamodel.metainfo.simulation.run import Run, Program
 from nomad.datamodel.metainfo.simulation.method import Method
 from nomad.datamodel.metainfo.simulation.system import System, Atoms
 from nomad.datamodel.metainfo.simulation.calculation import Calculation
-from nomad.datamodel.metainfo.simulation.workflow import (
-    Elastic, ElasticMethod, ElasticResults, StrainDiagrams)
-
+from simulationworkflowschema import (
+    Elastic, ElasticMethod, ElasticResults)
+from simulationworkflowschema.elastic import StrainDiagrams
 from .metainfo.elastic import x_elastic_section_fitting_parameters
 
 

--- a/workflowparsers/fhivibes/parser.py
+++ b/workflowparsers/fhivibes/parser.py
@@ -36,7 +36,7 @@ from nomad.datamodel.metainfo.simulation.system import (
 from nomad.datamodel.metainfo.simulation.calculation import (
     Calculation, Thermodynamics, Energy, EnergyEntry, Stress, StressEntry, Forces, ForcesEntry
 )
-from nomad.datamodel.metainfo.simulation.workflow import (
+from simulationworkflowschema import (
     SinglePoint, GeometryOptimization, MolecularDynamics, Phonon
 )
 from .metainfo.fhi_vibes import x_fhi_vibes_section_attributes,\

--- a/workflowparsers/phonopy/parser.py
+++ b/workflowparsers/phonopy/parser.py
@@ -39,9 +39,10 @@ from nomad.datamodel.metainfo.simulation.system import (
 from nomad.datamodel.metainfo.simulation.calculation import (
     Calculation, BandStructure, BandEnergies, Dos, DosValues, Thermodynamics
 )
-from nomad.datamodel.metainfo.simulation.workflow import (
-    Phonon, PhononMethod, PhononResults, Link, Task
+from simulationworkflowschema import (
+    Phonon, PhononMethod, PhononResults
 )
+from nomad.datamodel.metainfo.workflow import Link, Task
 from nomad.datamodel import EntryArchive
 
 from .metainfo import phonopy as phonopymetainfo  # pylint: disable=unused-import

--- a/workflowparsers/quantum_espresso_xspectra/parser.py
+++ b/workflowparsers/quantum_espresso_xspectra/parser.py
@@ -29,7 +29,7 @@ from nomad.datamodel.metainfo.simulation.method import (
 )
 from nomad.datamodel.metainfo.simulation.system import System, Atoms
 from nomad.datamodel.metainfo.simulation.calculation import Calculation, Spectra
-from nomad.datamodel.metainfo.simulation.workflow import SinglePoint
+from simulationworkflowschema import SinglePoint
 
 from .metainfo.quantum_espresso_xspectra import (
     x_qe_xspectra_input, x_qe_xspectra_n_parallel)


### PR DESCRIPTION
Simulation workflow schema are moved to a plug in https://github.com/nomad-coe/nomad-schema-plugin-simulation-workflow. References to the old schema are removed.